### PR TITLE
Change builder info button to trigger text on toggled click instead o…

### DIFF
--- a/src/components/builder/builder.css
+++ b/src/components/builder/builder.css
@@ -106,7 +106,7 @@
   width: 80px;
 }
 
-.control-panel button:hover {
+.control-panel button:click {
   opacity: 0.7;
 }
 
@@ -119,7 +119,7 @@
   --bs-gutter-x: 1rem; /*Gives room in row for units to fit in the card */
 }
 
-.build > .r-group-selection > .hover-info button {
+.build > .r-group-selection > .click-info button {
   background-color: #fdfbfb;
   border-radius: 12px;
   border-width: 1.8px;
@@ -127,12 +127,12 @@
   margin-top: 10px;
 }
 
-.build > .r-group-selection > .hover-info button:hover {
+.build > .r-group-selection > .click-info button:click {
   opacity: 0.7;
   background-color: #6a6c6e;
 }
 
-.build > .r-group-selection > .hover-info > .info-text {
+.build > .r-group-selection > .click-info > .info-text {
   border-style: solid;
   border-width: 1px;
   padding: 5px;

--- a/src/components/builder/builder.js
+++ b/src/components/builder/builder.js
@@ -29,7 +29,7 @@ class Builder extends React.Component {
           <div className="r-group-selection">
             <RGroupList r_group_pos={"A"} />
             <RGroupList r_group_pos={"B"} />
-            <div className="hover-info">
+            <div className="click-info">
               <button onClick={this.toggleInfo}>
                 ?
               </button>

--- a/src/components/builder/builder.js
+++ b/src/components/builder/builder.js
@@ -10,20 +10,19 @@ class Builder extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      hover: false,
+      info_requested: false,
     };
   }
 
-  onHover = (event) => {
-    this.setState({ hover: true });
-    console.log(this.props.help);
+  toggleInfo = (event) => {
+    const currentState = this.state.info_requested;
+    if (!currentState) {
+      console.log(this.props.help);
+    }
+    this.setState({ info_requested: !currentState });
   };
 
-  onUnHover = (event) => {
-    this.setState({ hover: false });
-  };
-
-  render() {
+  render = () => {
     return (
       <div className="wrapper">
         <div className="build">
@@ -31,10 +30,10 @@ class Builder extends React.Component {
             <RGroupList r_group_pos={"A"} />
             <RGroupList r_group_pos={"B"} />
             <div className="hover-info">
-              <button onMouseEnter={this.onHover} onMouseLeave={this.onUnHover}>
+              <button onClick={this.toggleInfo}>
                 ?
               </button>
-              {this.state.hover && (
+              {this.state.info_requested && (
                 <div className="info-text">
                   <p>
                     <div>{this.props.help[0]}</div>


### PR DESCRIPTION
When hovering over the info text '?' button on the Build page, if you move your mouse past the defined lines of the button, the info text disappears. However, on smaller screens, the text is so long that it extends past the bottom of the screen. Personally, I am unable to scroll through the info text without moving my mouse out of the hover radius.

This change modifies the behaviour of the button and renames some relevant variables. Rather than triggering on hovering, it triggers on a click. When the user clicks the '?' button, the text will show on the screen until the user selects the button again to get rid of the text. 