### PR TITLE
296 Fix order of assay data in analysis display

### DIFF
--- a/src/components/analysis/lipinski_display.js
+++ b/src/components/analysis/lipinski_display.js
@@ -11,6 +11,12 @@ class Lipinski extends React.Component {
     return (
       <div class="container" className="filter-stats">
         <div class="row" className="stats-type-header">
+          Date Created:
+        </div>
+        <div class="row">
+          Week {this.props.saved_mols[this.props.mol_id].data.date_created}
+        </div>
+        <div class="row" className="stats-type-header">
           Lipinski Filters:
         </div>
         <div class="row">
@@ -18,12 +24,6 @@ class Lipinski extends React.Component {
           {this.props.saved_mols[this.props.mol_id].data.lipinski.MW
             ? "Pass"
             : "Fail"}
-        </div>
-        <div class="row" className="stats-type-header">
-          Date Created:
-        </div>
-        <div class="row">
-          Week {this.props.saved_mols[this.props.mol_id].data.date_created}
         </div>
         <div class="row">
           H Acc.:{" "}

--- a/src/components/assay/lipinski_display.js
+++ b/src/components/assay/lipinski_display.js
@@ -26,7 +26,7 @@ class Lipinski extends React.Component {
           Week {this.props.saved_mols[this.props.mol_id].data.date_created}
         </div>
         <div class="row" className="stats-type-header">
-          Lipinski Rules:
+          Lipinski Filters:
         </div>
         <div class="row">
           MW:{" "}


### PR DESCRIPTION
- Date created field was in an incorrect place on the molecule widget of the Analysis page
- Also changes `Lipinski Rules` to `Lipinski Filters` on Assay page for consistency with other terminology