### PR TITLE
317 mol image size (checkout PR in backend too)

### DIFF
--- a/src/actions/init_actions.js
+++ b/src/actions/init_actions.js
@@ -27,6 +27,7 @@ function fetchHelp() {
 /**
  * Synchronous action that sends the r group object to the store when dispatched
  * @param {state object} r_group_obj the r_group state object
+ * @param {txt} size the desired size tuple of the image
  * @returns {} the r_group object for a state change by the initReducer
  */
 function fetchRGroupSucceeded(r_group_obj) {
@@ -46,14 +47,14 @@ function fetchRGroupSucceeded(r_group_obj) {
  * @returns {dispatch} dispatches fetchRGroupSucceeded with the r group object
  */
 
-function fetchRGroup(coutr) {
+function fetchRGroup(coutr,size) {
   const positions = ["A", "B"];
   var r_group_obj = {};
   for (const pos of positions) {
     for (let i = 1; i < 51; i++) {
       if (i < 10) {
         let id = String(pos + 0 + i);
-        api.fetchRGroup(id).then((response) => {
+        api.fetchRGroup(id,size).then((response) => {
           r_group_obj[id] = response;
         }).then(() => {
           coutr(Object.keys(r_group_obj).length);
@@ -61,7 +62,7 @@ function fetchRGroup(coutr) {
       } 
       else {
         let id = String(pos + i);
-        api.fetchRGroup(id).then((response) => {
+        api.fetchRGroup(id,size).then((response) => {
           r_group_obj[id] = response;
         }).then(() => {
           coutr(Object.keys(r_group_obj).length);

--- a/src/actions/init_actions.js
+++ b/src/actions/init_actions.js
@@ -95,7 +95,7 @@ export function fetchRocheSucceeded(Roche) {
  */
 export function fetchRoche() {
   return (dispatch) => {
-    api.fetchMolecule("A05", "B07", "800,800").then((response) => {
+    api.fetchMolecule("A05", "B07", "500,500").then((response) => {
       dispatch(fetchRocheSucceeded(response));
     });
   };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -12,9 +12,9 @@ const client = axios.create({
   },
 });
 
-export function fetchRGroup(id) {
+export function fetchRGroup(id,size) {
   client.defaults.headers["username"] = localStorage.user;
-  return client.get("/r-group-" + id);
+  return client.get("/r-group?rgroup=" + id + "&size=" + size);
 }
 
 export function fetchHelp() {

--- a/src/components/builder/r_group_list.js
+++ b/src/components/builder/r_group_list.js
@@ -22,7 +22,7 @@ class RGroupList extends React.Component {
           <RGroupWidget
             key={this.createRGroupID(this.props.r_group_pos, i + 1)}
             r_group_id={this.createRGroupID(this.props.r_group_pos, i + 1)}
-            size="800,800"
+            size="500,500" // changed from 800,800
           />
         ))}
       </div>

--- a/src/components/home/home.js
+++ b/src/components/home/home.js
@@ -20,7 +20,7 @@ class Home extends React.Component {
     this.props.selectRGroup(
       this.props.selected_r_groups["A"],
       this.props.selected_r_groups["B"],
-      "800,800"
+      "500,500"
     );
     this.props.fetchHelp();
   }

--- a/src/components/home/home.js
+++ b/src/components/home/home.js
@@ -16,7 +16,7 @@ class Home extends React.Component {
   // fetches the r groups from the BE and selects the first r groups at each position
   // ... for rapid rendering of the builder and sketcher pages
   componentWillMount() {
-    this.props.num < 100 && this.props.fetchRGroup(this.props.countRGroup);
+    this.props.num < 100 && this.props.fetchRGroup(this.props.countRGroup,"300,300");
     this.props.selectRGroup(
       this.props.selected_r_groups["A"],
       this.props.selected_r_groups["B"],

--- a/src/components/introduction/introduction.js
+++ b/src/components/introduction/introduction.js
@@ -14,7 +14,7 @@ class Introduction extends React.Component {
   }
   
   componentWillMount() {
-    this.props.num < 100 && this.props.fetchRGroup(this.props.countRGroup);
+    this.props.num < 100 && this.props.fetchRGroup(this.props.countRGroup,"300,300");
     this.props.selectRGroup(
       this.props.selected_r_groups["A"],
       this.props.selected_r_groups["B"],

--- a/src/components/introduction/introduction.js
+++ b/src/components/introduction/introduction.js
@@ -18,7 +18,7 @@ class Introduction extends React.Component {
     this.props.selectRGroup(
       this.props.selected_r_groups["A"],
       this.props.selected_r_groups["B"],
-      "800,800"
+      "500,500"
     );
     this.props.fetchHelp();
   }


### PR DESCRIPTION
Reduce size of R group images to 300,300 and of molecule images to 500,500
Should speed everything up + fix bug where on some screens molecule images on plot are not appearing
Need to checkout with PR 190-add-size-Rgroups in backend!! 