### PR TITLE
Analysis page redesign

### DIFF
--- a/src/components/analysis/selector_panel.js
+++ b/src/components/analysis/selector_panel.js
@@ -74,7 +74,7 @@ class SelectorPanel extends React.Component {
           )}
         <div className="selector-panel-select-button">
           <Link to="/results">
-              <button onClick={this.chooseMolecule}> Select Final Candidate</button>
+              <button onClick={this.chooseMolecule}>Select Final Candidate →</button>
           </Link>
         </div>
       </div>

--- a/src/components/analysis/the_plot.js
+++ b/src/components/analysis/the_plot.js
@@ -157,7 +157,7 @@ class ThePlot extends React.Component {
         <div className="plot-button-bigpanel">
         <div className="plot-button">
           <Link to="/assay">
-              <button>{'<< Test <<'}</button>
+              <button>{'← Test'}</button>
           </Link>
         </div>
         <div className="plot-button-panel">

--- a/src/components/assay/assay.css
+++ b/src/components/assay/assay.css
@@ -1,3 +1,7 @@
+.wrapper {
+  width: 100%;
+}
+
 .assay {
   display: flex;
   flex-direction: row;
@@ -17,7 +21,7 @@
   min-height: 100%;
   justify-content: center;
   padding-bottom: 10pt;
-  max-width: 255pt;
+  width: 25%;
 }
 
 .selected-mol-stats {
@@ -74,7 +78,7 @@
 }
 
 .molecule-widget > .molecule img {
-  width: 280px;
+  width: 100%;
 }
 
 .mol-stats {
@@ -92,9 +96,9 @@
   display: flex;
   flex-direction: column;
   background-color: white;
-  justify-content: space-between;
   padding: 10px;
   flex-grow: 1;
+  height: 90%;
 }
 
 .assay-name {
@@ -111,9 +115,10 @@
 }
 
 .assay-panel > .assay-table {
+  left: 50%;
   display: table-header-group;
   overflow-y: scroll;
-  width: 800px;
+  width: 100%;
   top: 150px;
 }
 
@@ -129,9 +134,7 @@
   background-color: #212529;
   color: white;
   border-radius: 8px;
-  max-width: 200px;
   flex: 1 1 auto;
-  max-height: 90px;
   margin-bottom: 10px;
   white-space: pre-line;
   width: 200px;
@@ -179,66 +182,6 @@
   width: max-content;
 }
 
-/* assay invoice toggle button */
-
-.invoice button {
-  display: flex;
-  border-width: 1px;
-  border-radius: 8px;
-}
-
-.invoice button:active {
-  background-color: #6a6c6e;
-}
-
-.invoice > .invoice-activebutton button {
-  background-color: #fdfbfb;
-}
-
-.invoice > .invoice-inactivebutton button {
-  background-color: #fdfbfb;
-}
-
-.invoice > .invoice-inactivebutton > .info-invoice button:active {
-  background-color: #6a6c6e;
-}
-
-
-.invoice > .invoice-activebutton > .info-invoice {
-  display: flex;
-  flex-direction: column;
-  border-style: solid;
-  border-width: 1px;
-  padding: 2px;
-  display: flex;
-  margin-left: 15px;
-  font-size: 15px;
-  z-index: 10;
-  position: absolute;
-  border-radius: 5px;
-  background-color: #fdfbfb;
-  white-space: pre-line;
-  width: 30vh;
-}
-
-.info-invoice {
-  display: flex;
-  flex-direction: column;
-  border-style: solid;
-  border-width: 1px;
-  padding: 2px;
-  display: flex;
-  margin-left: 70vw;
-  margin-top: 5vh;
-  font-size: 15px;
-  z-index: 10;
-  position: absolute;
-  border-radius: 5px;
-  background-color: #fdfbfb;
-  white-space: pre-line;
-  width: 30vh;
-}
-
 table {
   display: flex;
   border-collapse: separate;
@@ -280,7 +223,7 @@ table {
   padding: 5px;
   display: flex;
   margin-left: 22vh;
-  margin-top: 5px;
+  margin-top: 40px;
   font-size: 15px;
   z-index: 10;
   position: absolute;
@@ -296,7 +239,7 @@ table {
   padding: 5px;
   display: flex;
   margin-left: 40vh;
-  margin-top: 10px;
+  margin-top: 40px;
   font-size: 15px;
   z-index: 10;
   position: absolute;
@@ -536,36 +479,40 @@ table {
 }
 
 .assay-panel > .final-order {
-  display: flex;
-  flex-direction: row;
+  margin: auto;
+}
+
+.run-assay-button button {
+  position: relative;
+  float: right;
+  height: 100px;
+  width: 500px;
+  border: none;
   margin-top: 10px;
 }
 
-.assay-panel > .final-order span {
-  align-self: flex-end;
+.main-content {
+  display: flex;
+  flex-direction: column;
+  width: 75%;
+  margin-left: 20px;
 }
 
-.assay-panel > .final-order > .invoice {
-  margin-left: 15px;
+.nav-buttons {
+  display: flex;
+  justify-content: space-between;
+  height: 10%;
 }
 
-.assay-panel > .final-order button {
-  position: relative;
-  float: right;
-  margin-left: 30px;
-  height: 60px;
-  width: 130px;
-}
-
-.assay-panel > .final-order > .run-assay-button button {
-  margin-right: 130px;
-  width: 300px;
-}
-
-.assay-panel > .final-order > .nav-buttons button {
+.nav-buttons button {
   float: left;
-  position: flex;
-  flex-direction: row;
+  border: none;
+  background-color: #212529;
+  color: white;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  white-space: pre-line;
+  width: 200px;
 }
 
 .assay-panel > .assay-top-info {
@@ -573,13 +520,13 @@ table {
   flex-direction: row;
 }
 
-.assay-panel > .assay-top-info > .help-toggle {
+.help-toggle {
   margin-right: 20px;
   position: relative;
   margin-left: 20px;
 }
 
-.assay-panel > .assay-top-info > .help-toggle button {
+.help-toggle button {
   width: 24px;
   height: 30px;
   border-radius: 12px;
@@ -587,23 +534,31 @@ table {
   border-color: black;
 }
 
-.assay-panel > .assay-top-info > .help-toggle button:hover {
+.help-toggle button:hover {
   opacity: 0.7;
   background-color: #6a6c6e;
 }
 
-.assay-panel > .assay-top-info > .help-toggle button:active {
+.help-toggle button:active {
   background-color: #6a6c6e;
 }
 
-.assay-panel > .assay-top-info > .help-toggle > .toggle-inactivebutton button {
+.help-toggle > .toggle-inactivebutton button {
   background-color: #fdfbfb;
   border-width: 1.8px;
   color: black;
 }
 
-.assay-panel > .assay-top-info > .help-toggle > .toggle-activebutton button {
+.toggle-activebutton button {
   background-color: green;
   color: white;
   border-width: 1.8px;
+}
+
+.even {
+  background-color: #f2f2f2;
+}
+
+.odd {
+  background-color: #ffffff;
 }

--- a/src/components/assay/assay.css
+++ b/src/components/assay/assay.css
@@ -7,6 +7,7 @@
   padding-right: 3vw;
   padding-top: 3vh;
   padding-bottom: 3vh;
+  flex-grow: 1;
 }
 
 .molecule-chooser-bar {
@@ -16,49 +17,7 @@
   min-height: 100%;
   justify-content: center;
   padding-bottom: 10pt;
-  max-width: 250pt;
-}
-
-.assay_button {
-  display: flex;
-  background-color: mediumaquamarine;
-  flex-grow: 1;
-  align-items: center;
-  justify-content: center;
-  outline-style: solid;
-}
-
-.assay > .mol-visbox {
-  display: flex;
-  flex: 3;
-  flex-direction: column;
-}
-
-.assay > .mol-visbox > .rendered-molecule {
-  display: flex;
-  background-color: white;
-  padding: 15px;
-  padding-top: 0px;
-  padding-bottom: 0px;
-  justify-content: center;
-  align-content: center;
-  height: 45vh;
-  padding-top: 8vh;
-}
-
-.assay > .mol-visbox > .rendered-molecule > .molecule {
-  display: flex;
-  height: 45vh;
-  flex-direction: column;
-  justify-content: space-around;
-  align-content: space-around;
-}
-
-.assay > .mol-visbox > .rendered-molecule > .molecule img {
-  display: flex;
-  max-height: 100%;
-  justify-content: space-around;
-  align-content: space-around;
+  max-width: 255pt;
 }
 
 .selected-mol-stats {
@@ -91,6 +50,7 @@
   padding: 5px;
   background-color: white;
   overflow-y: scroll;
+  width: 100%;
 }
 
 .molecule-container {
@@ -114,7 +74,7 @@
 }
 
 .molecule-widget > .molecule img {
-  width: 240px;
+  width: 280px;
 }
 
 .mol-stats {
@@ -134,7 +94,7 @@
   background-color: white;
   justify-content: space-between;
   padding: 10px;
-  width: 20%;
+  flex-grow: 1;
 }
 
 .assay-name {
@@ -150,15 +110,27 @@
   padding: 10px;
 }
 
+.assay-panel > .assay-table {
+  display: table-header-group;
+  overflow-y: scroll;
+  width: 800px;
+  top: 150px;
+}
+
+.assay-panel > .assay-table tr.header-cells {
+  border: 1pt solid black;
+}
+
+.assay-panel > .assay-table tr.border-bottom td {
+  border-bottom: 1pt solid black;
+}
+
 .assay-panel button {
   background-color: #212529;
   color: white;
-  border: none;
   border-radius: 8px;
-  min-width: 100px;
   max-width: 200px;
   flex: 1 1 auto;
-  min-height: 40px;
   max-height: 90px;
   margin-bottom: 10px;
   white-space: pre-line;
@@ -179,6 +151,11 @@
 
 .assay-panel > .activebutton button {
   background-color: green;
+}
+
+.assay-panel input[type=checkbox]{
+    opacity: 1;
+    position: relative;
 }
 
 
@@ -202,40 +179,7 @@
   width: max-content;
 }
 
-.help-toggle {
-  z-index: 10;
-  margin-left: max(43vw, 570px);
-  position: absolute;
-}
-
-.help-toggle button {
-  border-width: 1px;
-  border-radius: 8px;
-}
-
-.help-toggle button:active {
-  background-color: #6a6c6e;
-}
-
-.help-toggle > .toggle-inactivebutton button {
-  background-color: #fdfbfb;
-}
-
-.help-toggle > .toggle-activebutton button {
-  background-color: green;
-    color: white;
-    border-radius: 6px;
-    border: hidden; 
-}
-
 /* assay invoice toggle button */
-
-
-.invoice {
-  z-index: 20;
-  margin-left: 80vw;
-  position: absolute;
-}
 
 .invoice button {
   display: flex;
@@ -302,6 +246,7 @@ table {
   text-indent: initial;
   border-spacing: 1px;
   border-color: burlywood;
+  width: 100%;
 }
 
 #cost {font-weight: bold;}
@@ -350,8 +295,8 @@ table {
   border-width: 1px;
   padding: 5px;
   display: flex;
-  margin-left: 22vh;
-  margin-top: 9.5vh;
+  margin-left: 40vh;
+  margin-top: 10px;
   font-size: 15px;
   z-index: 10;
   position: absolute;
@@ -366,8 +311,8 @@ table {
   border-width: 1px;
   padding: 5px;
   display: flex;
-  margin-left: 22vh;
-  margin-top: 18vh;
+  margin-left: 18vh;
+  margin-top: 5vh;
   font-size: 15px;
   z-index: 10;
   position: absolute;
@@ -382,8 +327,8 @@ table {
   border-width: 1px;
   padding: 5px;
   display: flex;
-  margin-left: 22vh;
-  margin-top: 27vh;
+  margin-left: 34vh;
+  margin-top: 5vh;
   font-size: 15px;
   z-index: 10;
   position: absolute;
@@ -427,8 +372,8 @@ table {
   border-width: 1px;
   padding: 5px;
   display: flex;
-  margin-left: 22vh;
-  margin-top: 35.5vh;
+  margin-left: 46vh;
+  margin-top: 5vh;
   font-size: 15px;
   z-index: 10;
   position: absolute;
@@ -475,15 +420,31 @@ table {
   border-width: 1px;
   padding: 5px;
   display: flex;
-  margin-left: 210px;
-  margin-top: 53vh;
+  margin-left: 20vh;
+  margin-top: 5vh;
   font-size: 15px;
   z-index: 10;
   position: absolute;
   border-radius: 5px;
   background-color: #fdfbfb;
   white-space: pre-line;
-  width: 15vw;
+  width: 35vh;
+}
+
+.hover-info-text-help {
+  border-style: solid;
+  border-width: 1px;
+  padding: 5px;
+  display: flex;
+  margin-left: 2vh;
+  margin-top: 5vh;
+  font-size: 15px;
+  z-index: 10;
+  position: absolute;
+  border-radius: 5px;
+  background-color: #fdfbfb;
+  white-space: pre-line;
+  width: 35vh;
 }
 
 .mol-stats > .hover-info-button-lip {
@@ -574,4 +535,75 @@ table {
   overflow-y: scroll;
 }
 
+.assay-panel > .final-order {
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+}
 
+.assay-panel > .final-order span {
+  align-self: flex-end;
+}
+
+.assay-panel > .final-order > .invoice {
+  margin-left: 15px;
+}
+
+.assay-panel > .final-order button {
+  position: relative;
+  float: right;
+  margin-left: 30px;
+  height: 60px;
+  width: 130px;
+}
+
+.assay-panel > .final-order > .run-assay-button button {
+  margin-right: 130px;
+  width: 300px;
+}
+
+.assay-panel > .final-order > .nav-buttons button {
+  float: left;
+  position: flex;
+  flex-direction: row;
+}
+
+.assay-panel > .assay-top-info {
+  display: flex;
+  flex-direction: row;
+}
+
+.assay-panel > .assay-top-info > .help-toggle {
+  margin-right: 20px;
+  position: relative;
+  margin-left: 20px;
+}
+
+.assay-panel > .assay-top-info > .help-toggle button {
+  width: 24px;
+  height: 30px;
+  border-radius: 12px;
+  border-width: 1.8px;
+  border-color: black;
+}
+
+.assay-panel > .assay-top-info > .help-toggle button:hover {
+  opacity: 0.7;
+  background-color: #6a6c6e;
+}
+
+.assay-panel > .assay-top-info > .help-toggle button:active {
+  background-color: #6a6c6e;
+}
+
+.assay-panel > .assay-top-info > .help-toggle > .toggle-inactivebutton button {
+  background-color: #fdfbfb;
+  border-width: 1.8px;
+  color: black;
+}
+
+.assay-panel > .assay-top-info > .help-toggle > .toggle-activebutton button {
+  background-color: green;
+  color: white;
+  border-width: 1.8px;
+}

--- a/src/components/assay/assay.css
+++ b/src/components/assay/assay.css
@@ -102,7 +102,7 @@
 }
 
 .assay-name {
-  font-size: 2vh;
+  font-size: 18px;
 }
 
 .assay-cost-and-time {
@@ -120,6 +120,14 @@
   overflow-y: scroll;
   width: 100%;
   top: 150px;
+}
+
+.assay-panel > .assay-table th{
+  padding: 5px;
+}
+
+.assay-panel > .assay-table td{
+  padding: 5px;
 }
 
 .assay-panel > .assay-table tr.header-cells {
@@ -486,7 +494,7 @@ table {
   position: relative;
   float: right;
   height: 100px;
-  width: 500px;
+  width: 400px;
   border: none;
   margin-top: 10px;
 }
@@ -555,10 +563,18 @@ table {
   border-width: 1.8px;
 }
 
+.invoice-amount {
+  font-size: 12px;
+}
+
 .even {
   background-color: #f2f2f2;
 }
 
 .odd {
   background-color: #ffffff;
+}
+
+.header-cells {
+  background-color: #f2f2f2;
 }

--- a/src/components/assay/assay.js
+++ b/src/components/assay/assay.js
@@ -31,7 +31,26 @@ class Assay extends React.Component {
           <div className="molecule-chooser-bar">
             <MoleculeList />
           </div>
-          <AssayPanel />
+          <div className="main-content">
+            <AssayPanel />
+            <div className="nav-buttons">
+              <Link to="/build">
+                <button
+                  label="Back_Build"
+                >
+                  Back (Design)
+                </button>
+              </Link>
+              <Link to="/analysis">
+                <button
+                  label="Next_Analysis"
+                  onClick={this.initPlotData}
+                >
+                  Next (Analysis)
+                </button>
+              </Link>
+            </div>
+          </div>
             </div>) : (<div className='unsavedmol'>       
                     <Link to="/loadingpage">
                       <button className="mk_pre_test_button">Please make a molecule before test!</button>

--- a/src/components/assay/assay.js
+++ b/src/components/assay/assay.js
@@ -9,86 +9,10 @@ import ControlPanel from "./control_panel.js";
 import { assayActions } from "../../actions";
 import { Link } from "react-router-dom"
 
-class InvoiceAmount extends React.Component {
-  constructor(props) {
-    super(props); 
-  };
-
-  render() {
-    return (
-      <div className="invoice-amount">
-        Running all of your assays will cost: {'\n'}
-        £{this.props.cost} {'\n'} Duration: {this.props.time} weeks
-      </div>
-    )
-  }
-}
-
 class Assay extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      invoice_display: false,
-      cost_assays: [],
-    };
   }
-
-
-  runAssays = () => {
-    const ASSAY_PRICES = {
-      pIC50: 70.0,
-      clearance_mouse: 7000.0,
-      clearance_human: 9000.0,
-      logd: 1000.0,
-      pampa: 700.0,
-    };
-    const ASSAY_TIMES = {
-      pIC50: 1.0,
-      clearance_mouse: 3.0,
-      clearance_human: 3.5,
-      logd: 1.5,
-      pampa: 1.0,
-    };
-
-    // iterate through all saved molecules at once
-    let max_time = 0.
-    let total_cost = 0.
-
-    for ( var molecule_key in this.props.all_molecules_assay_data ) {
-
-      let assays_run = this.props.all_molecules_assay_data[molecule_key].data.assays_run ;
-      let toggle_assay_dict = this.props.all_molecules_assay_data[molecule_key].data.toggle_assay;
-
-      // iterate through toggle_assay, if assay_value is true, add to selected assay
-      let arr = []
-      for (var key in toggle_assay_dict){
-        if (toggle_assay_dict[key]) {
-          arr.push(key)
-        }
-      }
-      let selected_assays = arr;
-
-      for (var i = 0; i < selected_assays.length; i++) {
-        if (
-          ["drug_props", "lipinski", "descriptors"].includes(selected_assays[i])
-        ) 
-          {} 
-        else {
-            if (!assays_run[selected_assays[i]]){
-              if (max_time < ASSAY_TIMES[selected_assays[i]]) {
-                max_time = ASSAY_TIMES[selected_assays[i]] ;
-              }
-              total_cost = total_cost + ASSAY_PRICES[selected_assays[i]] ;
-          }
-        }
-      }
-    }
-    let cost = {
-      'time': max_time, 
-      'money': total_cost,
-  }
-    return cost
-  };
 
   toggleHelp() {
     if (this.props.toggle_help) {
@@ -98,83 +22,21 @@ class Assay extends React.Component {
     }
     console.log(this.props.toggle_help)
   }
-  
-
-  invoiceDisplay() {
-    if (this.state.invoice_display) {
-      this.setState({invoice_display: false}) ;
-    } else {
-      this.setState({invoice_display: true}) ;
-    }
-  }
-
-
-
 
   render() {
     return (
       <div className="wrapper">
         {this.props.saved_or_not ? (
         <div className="assay">
-          <div className="display-buttons-assay">
-            <div className="help-toggle">
-              {this.props.toggle_help && (
-                <div className="toggle-activebutton">
-                  <button onClick={() => this.toggleHelp()}>?</button>
-                </div>
-              )}
-              {this.props.toggle_help == false && (
-                <div className="toggle-inactivebutton">
-                  <button onClick={() => this.toggleHelp()}>?</button>
-                </div>
-              )}
-            </div>
-            <div className="invoice">
-              {this.state.invoice_display && (
-                <div className="invoice-activebutton">
-                  <button onClick={() => {this.invoiceDisplay(); }}>Hide invoice</button>
-                </div>
-              )}
-
-
-              {this.state.invoice_display == false && (
-                <div className="invoice-inactivebutton">
-                  <button onClick={() => {
-                    this.invoiceDisplay(); 
-                    }}>
-                    Show invoice     
-                  </button>
-                </div>
-              )}
-            </div>
-            {this.state.invoice_display && (
-                    <div className="info-invoice">
-                      <text>
-                      Currently viewing molecule {this.props.selected_mol}{"\n"}
-                      </text>
-                      <InvoiceAmount cost={this.runAssays().money} time={this.runAssays().time}/> 
-                    </div>
-              )}
-
-            </div> 
           <div className="molecule-chooser-bar">
             <MoleculeList />
           </div>
           <AssayPanel />
-          <div className="mol-visbox">
-            <div className="rendered-molecule">
-              <MoleculeImage mol_id={this.props.selected_mol} />
-            </div>
-            <div className="selected-mol-stats">
-                <MoleculeStats selected_mol={this.props.selected_mol} />
-                <ControlPanel />
-              </div>
-            </div> </div>) : (<div className='unsavedmol'>       
+            </div>) : (<div className='unsavedmol'>       
                     <Link to="/loadingpage">
                       <button className="mk_pre_test_button">Please make a molecule before test!</button>
                     </Link></div>)
             }
-
         </div>
       );
 
@@ -186,6 +48,8 @@ function mapStateToProps(state) {
     toggle_help: state.assay.toggle_help,
     saved_or_not: state.assay.saved_or_not,
     all_molecules_assay_data: state.assay.saved_mols,
+    money: state.game.money,
+    time: state.game.time,
   };
 }
 

--- a/src/components/assay/assay.js
+++ b/src/components/assay/assay.js
@@ -38,7 +38,7 @@ class Assay extends React.Component {
                 <button
                   label="Back_Build"
                 >
-                  Back (Design)
+                  ← Design 
                 </button>
               </Link>
               <Link to="/analysis">
@@ -46,7 +46,7 @@ class Assay extends React.Component {
                   label="Next_Analysis"
                   onClick={this.initPlotData}
                 >
-                  Next (Analysis)
+                  Analysis →
                 </button>
               </Link>
             </div>

--- a/src/components/assay/assay.js
+++ b/src/components/assay/assay.js
@@ -7,6 +7,7 @@ import AssayPanel from "./assay_panel.js";
 import MoleculeStats from "./molecule_stats.js";
 import ControlPanel from "./control_panel.js";
 import { assayActions } from "../../actions";
+import { analysisActions } from "../../actions";
 import { Link } from "react-router-dom"
 
 class Assay extends React.Component {
@@ -22,6 +23,13 @@ class Assay extends React.Component {
     }
     console.log(this.props.toggle_help)
   }
+
+  initPlotData = () => {
+    // creates object for plotting - firing it here just speeds 
+    // ...things up a bit
+    console.log(this.props.saved_mols);
+    this.props.constructPlotObj(this.props.saved_mols);
+  };
 
   render() {
     return (
@@ -69,11 +77,13 @@ function mapStateToProps(state) {
     all_molecules_assay_data: state.assay.saved_mols,
     money: state.game.money,
     time: state.game.time,
+    saved_mols: state.assay.saved_mols,
   };
 }
 
 const actionCreators = {
   toggleHelp: assayActions.toggleHelp,
+  constructPlotObj: analysisActions.constructPlotObj,
 };
 
 export default connect(mapStateToProps, actionCreators)(Assay);

--- a/src/components/assay/assay_panel.js
+++ b/src/components/assay/assay_panel.js
@@ -1,6 +1,7 @@
 import React from "react";
 import "./assay.css";
 import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 import { assayActions, gameActions } from "../../actions";
 
 class AssayPanel extends React.Component {
@@ -11,7 +12,6 @@ class AssayPanel extends React.Component {
       assays_run: null,
       selected_mol: null,
       hover: [],
-      
     };
   }
 
@@ -42,9 +42,16 @@ class AssayPanel extends React.Component {
     this.props.updateMoney(cost, this.props.money);
   };
 
+  toggleHelp() {
+    if (this.props.toggle_help) {
+      this.props.toggleHelp(false);
+    } else {
+      this.props.toggleHelp(true);
+    }
+    console.log(this.props.toggle_help)
+  }
 
-
-  runAssays = () => {
+  runAssaysLimit = () => {
     const ASSAY_PRICES = {
       pIC50: 70.0,
       clearance_mouse: 7000.0,
@@ -66,7 +73,7 @@ class AssayPanel extends React.Component {
 
     for ( var molecule_key in this.props.all_molecules_assay_data ) {
 
-      let assays_run = this.props.all_molecules_assay_data[molecule_key].data.assays_run ;
+      let assays_run = this.props.all_molecules_assay_data[molecule_key].data.assays_run;
       let toggle_assay_dict = this.props.all_molecules_assay_data[molecule_key].data.toggle_assay;
 
       // iterate through toggle_assay, if assay_value is true, add to selected assay
@@ -84,24 +91,113 @@ class AssayPanel extends React.Component {
         ) 
           {} 
         else {
-          if (this.props.money - ASSAY_PRICES[selected_assays[i]] < 0) {
-            this.removeselectedAssays(selected_assays[i]);
-          } else if (this.props.time - ASSAY_TIMES[selected_assays[i]] < 0) {
-            this.removeselectedAssays(selected_assays[i]);
-          } else {
+            if (!assays_run[selected_assays[i]]){
+              if (max_time < ASSAY_TIMES[selected_assays[i]]) {
+                max_time = ASSAY_TIMES[selected_assays[i]] ;
+              }
+              total_cost = total_cost + ASSAY_PRICES[selected_assays[i]] ;
+          }
+        }
+      }
+    }
+    let cost = {
+      'time': max_time, 
+      'money': total_cost,
+  }
+    return cost
+  };
+
+  runAssays = () => {
+    const ASSAY_PRICES = {
+      pIC50: 70.0,
+      clearance_mouse: 7000.0,
+      clearance_human: 9000.0,
+      logd: 1000.0,
+      pampa: 700.0,
+    };
+    const ASSAY_TIMES = {
+      pIC50: 1.0,
+      clearance_mouse: 3.0,
+      clearance_human: 3.5,
+      logd: 1.5,
+      pampa: 1.0,
+    };
+
+    // iterate through all saved molecules at once
+    let max_time = 0.
+    let total_cost = 0.
+
+    // Ensure that total assay costs/times are under the limit
+    let cost_sum = 0;
+    let time_sum = 0;
+    for ( var molecule_key in this.props.all_molecules_assay_data ) {
+      let assays_run = this.props.all_molecules_assay_data[molecule_key].data.assays_run;
+      let toggle_assay_dict = this.props.all_molecules_assay_data[molecule_key].data.toggle_assay;
+
+      // iterate through toggle_assay, if assay_value is true, add to selected assay
+      let arr = []
+      for (var key in toggle_assay_dict){
+        if (toggle_assay_dict[key]) {
+          arr.push(key)
+        }
+      }
+      let selected_assays = arr;
+
+      // iterate through selected assays and ensure that they do not exceed cost/time limits
+      for (var i = 0; i < selected_assays.length; i++) {
+        if (!["drug_props", "lipinski", "descriptors"].includes(selected_assays[i]) && !assays_run[selected_assays[i]]) {
+          cost_sum += ASSAY_PRICES[selected_assays[i]];
+          time_sum += ASSAY_TIMES[selected_assays[i]];
+        }
+      }
+    }
+
+    if (this.props.money - cost_sum < 0 || this.props.time - time_sum < 0) {
+      for ( var molecule_key in this.props.all_molecules_assay_data ) {
+        let toggle_assay_dict = this.props.all_molecules_assay_data[molecule_key].data.toggle_assay;
+
+        let arr = []
+        for (var key in toggle_assay_dict){
+          if (toggle_assay_dict[key]) {
+            arr.push(key)
+          }
+        }
+        let selected_assays = arr;
+
+        for (var i = 0; i < selected_assays.length; i++) {
+          this.removeselectedAssays(selected_assays[i]);
+        }
+      }
+      window.alert("Your choice of assays exceeds the cost and time limits! Please unselect some assays or proceed to Analysis");
+    } else {
+      for ( var molecule_key in this.props.all_molecules_assay_data ) {
+        let assays_run = this.props.all_molecules_assay_data[molecule_key].data.assays_run;
+        let toggle_assay_dict = this.props.all_molecules_assay_data[molecule_key].data.toggle_assay;
+
+        let arr = []
+        for (var key in toggle_assay_dict){
+          if (toggle_assay_dict[key]) {
+            arr.push(key)
+          }
+        }
+        let selected_assays = arr;
+
+        for (var i = 0; i < selected_assays.length; i++) {
+          if (!["drug_props", "lipinski", "descriptors"].includes(selected_assays[i])) {
             if (!assays_run[selected_assays[i]]){
               assays_run[selected_assays[i]] = true;
               if (max_time < ASSAY_TIMES[selected_assays[i]]) {
                 max_time = ASSAY_TIMES[selected_assays[i]] ;
               }
               total_cost = total_cost + ASSAY_PRICES[selected_assays[i]] ;
-          }
+            }
           }
         }
+        assays_run["drug_props"] = true;
+        this.props.runAssay(molecule_key, assays_run);
       }
-      assays_run["drug_props"] = true;
-      this.props.runAssay(molecule_key, assays_run);
     }
+
     this.updateTime(max_time);
     this.updateMoney(total_cost);
 
@@ -119,10 +215,12 @@ class AssayPanel extends React.Component {
   };
 
   // select the assay
-  onClick = (label) => {
+  onClick = (label, isDisabled) => {
     let arr = this.state.selected_assays;
-    if (arr.includes(label) == false) {
-      arr.push(label);
+    if (!isDisabled) {
+      if (!arr.includes(label)) {
+        arr.push(label);
+      }
     }
     this.setState({ selected_assays: arr });
   };
@@ -150,115 +248,237 @@ class AssayPanel extends React.Component {
     this.setState({ hover: [] });
   };
 
-  toggleAssay = (assay_type) => {
-    if (this.props.toggle_assay[assay_type]) {
-      this.props.toggleAssay(this.props.selected_mol,assay_type,false);
+  toggleAssay = (assay_type, mol_id) => {
+      let toggle_assay = this.props.saved_mols[mol_id].data.toggle_assay;
+      if (toggle_assay[assay_type]) {
+      this.props.toggleAssay(mol_id,assay_type,false);
     } else {
-      this.props.toggleAssay(this.props.selected_mol,assay_type,true);
+      this.props.toggleAssay(mol_id,assay_type,true);
     }
   }
-// or this.props.toggle_assay.button
+
+  checkAssaysRun = (assay_type, mol_id) => {
+    let assays_run = this.props.all_molecules_assay_data[mol_id].data.assays_run;
+    return assays_run[assay_type];
+  }
+
   render() {
+    const data = Object.keys(this.props.all_molecules_assay_data);
+    const cost_color = {
+      color: (this.props.money - this.runAssaysLimit().money >= 0 ? "black" : "red"),
+    };
+    const duration_color = {
+      color: (this.props.time - this.runAssaysLimit().time >= 0 ? "black" : "red"),
+    };
     return(
       <div className="assay-panel">
-        {this.props.toggle_assay.pIC50 && (
-          <div className="activebutton">
-            <button onClick={() => {
-              this.toggleAssay("pIC50");
-              this.onClick("pIC50");
-              }}
-              onMouseEnter={() => {
-                this.onHover("pic50");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">pIC50</div>
-              <div className="assay-cost-and-time">
-                <p>
-                  {""}
-                  Cost £70
-                  {"\n"}Duration: 1 week
-                </p>
+        <div className="assay-top-info">
+          <div className="invoice">
+            <b>Order assays here: </b>
+            <div className="invoice-amount">
+              <div style={duration_color}>
+                Duration: {this.runAssaysLimit().time} weeks
               </div>
-            </button></div>
-        )}
-        {this.props.toggle_assay.pIC50 == false && (
-          <div className="inactivebutton">
-            <button onClick={() => {
-              this.toggleAssay("pIC50");
-              this.onClick("pIC50");
-              }}
-              onMouseEnter={() => {
-                this.onHover("pic50");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
+              <div style={cost_color}>
+                Cost: £{this.runAssaysLimit().money}
+              </div>
+            </div>
+          </div>
+          <div className="help-toggle">
+            {this.props.toggle_help && (
+              <div className="toggle-activebutton">
+                <button 
+                  onClick={() => this.toggleHelp()}
+                  onMouseEnter={() => {
+                    this.onHover("help");
+                  }}
+                  onMouseLeave={() => {
+                    this.onUnHover();
+                  }}
+                >
+                  ?
+                </button>
+              </div>
+            )}
+            {this.props.toggle_help == false && (
+              <div className="toggle-inactivebutton">
+                <button 
+                  onClick={() => this.toggleHelp()}
+                  onMouseEnter={() => {
+                    this.onHover("help");
+                  }}
+                  onMouseLeave={() => {
+                    this.onUnHover();
+                  }}
+                >
+                  ?
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+        <table className="assay-table" style={{overflowWrap: 'break-word'}}>
+        <colgroup>
+          <col width="15%"/>
+          <col width="17%"/>
+          <col width="17%"/>
+          <col width="17%"/>
+          <col width="17%"/>
+          <col width="17%"/>
+        </colgroup>
+          <thead>
+            <tr class="header-cells">
+              <th>{" "}</th>
+              <th
+                onMouseEnter={() => {
+                  this.onHover("pic50");
+                }}
+                onMouseLeave={() => {
+                  this.onUnHover();
+                }}
               >
-              <div className="assay-name">pIC50</div>
-              <div className="assay-cost-and-time">
-                <p>
-                  {" "}
-                  Cost £70
-                  {"\n"}Duration: 1 week
-                </p></div></button></div>
-        )}
+                pIC50
+              </th>
+              <th
+                onMouseEnter={() => {
+                  this.onHover("clrmouse");
+                }}
+                onMouseLeave={() => {
+                  this.onUnHover();
+                }}
+              >
+                Mouse Clearance
+              </th>
+              <th
+                onMouseEnter={() => {
+                  this.onHover("clrhuman");
+                }}
+                onMouseLeave={() => {
+                  this.onUnHover();
+                }}
+              >
+                Human Clearance
+              </th>
+              <th
+                onMouseEnter={() => {
+                  this.onHover("logd");
+                }}
+                onMouseLeave={() => {
+                  this.onUnHover();
+                }}
+              >
+                LogD
+              </th>
+              <th
+                onMouseEnter={() => {
+                  this.onHover("pampa");
+                }}
+                onMouseLeave={() => {
+                  this.onUnHover();
+                }}
+              >
+                PAMPA
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><b>Cost per assay</b></td>
+              <td>£70</td>
+              <td>£7,000</td>
+              <td>£9,000</td>
+              <td>£1,000</td>
+              <td>£700</td>
+            </tr>
+            <tr class="border-bottom">
+              <td><b>Duration</b></td>
+              <td>1 week</td>
+              <td>3 weeks</td>
+              <td>3.5 weeks</td>
+              <td>1.5 weeks</td>
+              <td>1 week</td>
+            </tr>
+            <tr>
+              <td><b>Molecule</b></td>
+              <td>{" "}</td>
+              <td>{" "}</td>
+              <td>{" "}</td>
+              <td>{" "}</td>
+              <td>{" "}</td>
+            </tr>
+            {data.map((val) => (
+              <tr key={val}>
+                <td>{val}</td>
+                <td>
+                  <input type="checkbox"  
+                    id={"pIC50" + val}
+                    disabled={this.checkAssaysRun("pIC50", val)}
+                    checked={this.checkAssaysRun("pIC50", val)}
+                    onClick={() => {
+                    this.toggleAssay("pIC50", val); 
+                    const isDisabled = this.checkAssaysRun("pIC50", val);
+                    this.onClick("pIC50", isDisabled);
+                    }}
+                  />
+                </td>
+                <td>
+                  <input type="checkbox"
+                    id={"clearance_mouse" + val}
+                    disabled={this.checkAssaysRun("clearance_mouse", val)}
+                    checked={this.checkAssaysRun("clearance_mouse", val)}
+                    onClick={() => {
+                    this.toggleAssay("clearance_mouse", val);
+                    const isDisabled = this.checkAssaysRun("clearance_mouse", val);
+                    this.onClick("clearance_mouse", isDisabled);
+                    }}
+                  />
+                </td>
+                <td>
+                  <input type="checkbox" 
+                    id={"clearance_human" + val}
+                    disabled={this.checkAssaysRun("clearance_human", val)}
+                    checked={this.checkAssaysRun("clearance_human", val)}
+                    onClick={() => {
+                    this.toggleAssay("clearance_human", val);
+                    const isDisabled = this.checkAssaysRun("clearance_human", val);
+                    this.onClick("clearance_human", isDisabled);
+                    }}
+                  />
+                </td>
+                <td>
+                  <input type="checkbox" 
+                    id={"logd" + val}
+                    disabled={this.checkAssaysRun("logd", val)}
+                    checked={this.checkAssaysRun("logd", val)}
+                    onClick={() => {
+                    this.toggleAssay("logd", val);
+                    const isDisabled = this.checkAssaysRun("logd", val);
+                    this.onClick("logd", isDisabled);
+                    }}
+                  />
+                </td>
+                <td>
+                  <input type="checkbox"
+                    id={"pampa" + val}
+                    disabled={this.checkAssaysRun("pampa", val)}
+                    checked={this.checkAssaysRun("pampa", val)}
+                    onClick={() => {
+                    this.toggleAssay("pampa", val);
+                    const isDisabled = this.checkAssaysRun("pampa", val);
+                    this.onClick("pampa", isDisabled);
+                    }}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
         {this.state.hover == "pic50" && this.props.toggle_help && (
         <div className="hover-info-text-pic50">
           <p>
             <div>{this.props.help[0]}</div>
           </p>
         </div>
-        )}
-        
-        {this.props.toggle_assay.clearance_mouse && (
-          <div className="activebutton">
-            <button onClick={() => {
-              this.toggleAssay("clearance_mouse");
-              this.onClick("clearance_mouse");
-              }}
-              onMouseEnter={() => {
-                this.onHover("clrmouse");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">Mouse Clearance</div>
-              <div className="assay-cost-and-time">
-                <p>
-                  {" "}
-                  Cost £7,000
-                  {"\n"}Duration: 3 weeks
-                </p></div>
-              </button>
-          </div>
-        )}
-        {this.props.toggle_assay.clearance_mouse == false && (
-          <div className="inactivebutton">
-            <button onClick={() => {
-              this.toggleAssay("clearance_mouse");
-              this.onClick("clearance_mouse");
-              }}
-              onMouseEnter={() => {
-                this.onHover("clrmouse");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">Mouse Clearance</div>
-              <div className="assay-cost-and-time">
-                <p>
-                  {" "}
-                  Cost £7,000
-                  {"\n"}Duration: 3 weeks
-                </p>
-              </div>
-              </button>
-          </div>
         )}
         {this.state.hover == "clrmouse" && this.props.toggle_help && (
         <div className="hover-info-text-clrmouse">
@@ -267,110 +487,12 @@ class AssayPanel extends React.Component {
           </p>
         </div>
         )}
-
-        {this.props.toggle_assay.clearance_human && (
-          <div className="activebutton">
-            <button onClick={() => {
-              this.toggleAssay("clearance_human");
-              this.onClick("clearance_human");
-              }}
-              onMouseEnter={() => {
-                this.onHover("clrhuman");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">Human Clearance</div>
-              <div className="assay-cost-and-time">
-                <p>
-                {" "}
-                Cost £9,000
-                {"\n"}Duration: 3.5 weeks
-                </p>
-              </div>
-              </button>
-          </div>
-        )}
-        {this.props.toggle_assay.clearance_human == false && (
-          <div className="inactivebutton">
-            <button onClick={() => {
-              this.toggleAssay("clearance_human");
-              this.onClick("clearance_human");
-              }}
-              onMouseEnter={() => {
-                this.onHover("clrhuman");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">Human Clearance</div>
-              <div className="assay-cost-and-time">
-              <p>
-                {" "}
-                Cost £9,000
-                {"\n"}Duration: 3.5 weeks
-                </p>
-              </div>
-              </button>
-          </div>
-        )}
         {this.state.hover == "clrhuman" && this.props.toggle_help && (
         <div className="hover-info-text-clrhuman">
           <p>
             <div>{this.props.help[2]}</div>
           </p>
         </div>
-        )}
-
-        {this.props.toggle_assay.logd && (
-          <div className="activebutton">
-            <button onClick={() => {
-              this.toggleAssay("logd");
-              this.onClick("logd");
-              }}
-              onMouseEnter={() => {
-                this.onHover("logd");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">LogD</div>
-              <div className="assay-cost-and-time">
-              <p>
-                  {" "}
-                  Cost £1,000
-                  {"\n"}Duration: 1.5 week
-                </p>
-              </div>
-              </button>
-          </div>
-        )}
-        {this.props.toggle_assay.logd == false && (
-          <div className="inactivebutton">
-            <button onClick={() => {
-              this.toggleAssay("logd");
-              this.onClick("logd");
-              }}
-              onMouseEnter={() => {
-                this.onHover("logd");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">Log D</div>
-              <div className="assay-cost-and-time">
-                <p>
-                  {" "}
-                  Cost £1,000
-                  {"\n"}Duration: 1.5 week
-                </p>
-              </div>
-              </button>
-          </div>
         )}
         {this.state.hover == "logd" && this.props.toggle_help && (
         <div className="hover-info-text-logd">
@@ -379,54 +501,6 @@ class AssayPanel extends React.Component {
           </p>
         </div>
         )}
-        {this.props.toggle_assay.pampa && (
-          <div className="activebutton">
-            <button onClick={() => {
-              this.toggleAssay("pampa");
-              this.onClick("pampa");
-              }}
-              onMouseEnter={() => {
-                this.onHover("pampa");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">PAMPA</div>
-              <div className="assay-cost-and-time">
-              <p>
-                  {" "}
-                  Cost £700
-                  {"\n"}Duration: 1 week
-                </p>
-              </div>
-              </button>
-          </div>
-        )}
-        {this.props.toggle_assay.pampa == false && (
-          <div className="inactivebutton">
-            <button onClick={() => {
-              this.toggleAssay("pampa");
-              this.onClick("pampa");
-              }}
-              onMouseEnter={() => {
-                this.onHover("pampa");
-              }}
-              onMouseLeave={() => {
-                this.onUnHover();
-              }}
-              >
-              <div className="assay-name">PAMPA</div>
-              <div className="assay-cost-and-time">
-                <p>
-                  {" "}
-                  Cost £700
-                  {"\n"}Duration: 1 week
-                </p>
-              </div>
-              </button>
-          </div>
-        )}
         {this.state.hover == "pampa" && this.props.toggle_help && (
         <div className="hover-info-text-pampa">
           <p>
@@ -434,28 +508,56 @@ class AssayPanel extends React.Component {
           </p>
         </div>
         )}
-        <button
-          label="Run_Assays"
-          onClick={() => {
-            this.onClick("drug_props");
-            this.runAssays();
-          }}
-          onMouseEnter={() => {
-            this.onHover("run");
-          }}
-          onMouseLeave={() => {
-            this.onUnHover();
-          }}
-        >
-          <div className="assay-name">Run Assays</div>
-        </button>
-        {this.state.hover == "run" && this.props.toggle_help && (
-          <div className="hover-info-text-run">
-            <p>
-              <div>{this.props.help[7]}</div>
-            </p>
-          </div>
+        {this.state.hover == "help" && (
+        <div className="hover-info-text-help">
+          <p>
+            <div>{this.props.help[9]}</div>
+          </p>
+        </div>
         )}
+        <div className="final-order">
+          <div className="run-assay-button">
+            <button
+              label="Run_Assays"
+              onClick={() => {
+                this.onClick("drug_props");
+                this.runAssays();
+              }}
+              onMouseEnter={() => {
+                this.onHover("run");
+              }}
+              onMouseLeave={() => {
+                this.onUnHover();
+              }}
+            >
+              <div className="assay-name">Run Assays</div>
+            </button>
+            {this.state.hover == "run" && this.props.toggle_help && (
+              <div className="hover-info-text-run">
+                <p>
+                  <div>{this.props.help[6]}</div>
+                </p>
+              </div>
+            )}
+          </div>
+          <div className="nav-buttons">
+            <Link to="/build">
+              <button 
+                label="Back_Build" 
+              >
+                Back (Design)
+              </button>
+            </Link>
+            <Link to="/analysis">
+              <button 
+                label="Next_Analysis" 
+                onClick={this.initPlotData}
+              >
+                Next (Analysis)
+              </button>
+            </Link>
+          </div>
+        </div>
       </div>
     );
   }
@@ -472,7 +574,7 @@ function mapStateToProps(state) {
     subtotal: state.game.subtotal,
     help: state.init.help.assay,
     toggle_help: state.assay.toggle_help,
-    toggle_assay: state.assay.saved_mols[state.selector.selected_mol].data.toggle_assay,
+    saved_mols: state.assay.saved_mols,
     all_molecules_assay_data: state.assay.saved_mols,
   };
 }
@@ -482,6 +584,7 @@ const actionCreators = {
   updateTime: gameActions.updateTime,
   runAssay: assayActions.runAssay,
   toggleAssay: assayActions.toggleAssay,
+  toggleHelp: assayActions.toggleHelp,
 };
 
 export default connect(mapStateToProps, actionCreators)(AssayPanel);

--- a/src/components/assay/assay_panel.js
+++ b/src/components/assay/assay_panel.js
@@ -265,58 +265,13 @@ class AssayPanel extends React.Component {
   render() {
     const data = Object.keys(this.props.all_molecules_assay_data);
     const cost_color = {
-      color: (this.props.money - this.runAssaysLimit().money >= 0 ? "black" : "red"),
+      color: (this.props.money - this.runAssaysLimit().money >= 0 ? "white" : "red"),
     };
     const duration_color = {
-      color: (this.props.time - this.runAssaysLimit().time >= 0 ? "black" : "red"),
+      color: (this.props.time - this.runAssaysLimit().time >= 0 ? "white" : "red"),
     };
     return(
       <div className="assay-panel">
-        <div className="assay-top-info">
-          <div className="invoice">
-            <b>Order assays here: </b>
-            <div className="invoice-amount">
-              <div style={duration_color}>
-                Duration: {this.runAssaysLimit().time} weeks
-              </div>
-              <div style={cost_color}>
-                Cost: £{this.runAssaysLimit().money}
-              </div>
-            </div>
-          </div>
-          <div className="help-toggle">
-            {this.props.toggle_help && (
-              <div className="toggle-activebutton">
-                <button 
-                  onClick={() => this.toggleHelp()}
-                  onMouseEnter={() => {
-                    this.onHover("help");
-                  }}
-                  onMouseLeave={() => {
-                    this.onUnHover();
-                  }}
-                >
-                  ?
-                </button>
-              </div>
-            )}
-            {this.props.toggle_help == false && (
-              <div className="toggle-inactivebutton">
-                <button 
-                  onClick={() => this.toggleHelp()}
-                  onMouseEnter={() => {
-                    this.onHover("help");
-                  }}
-                  onMouseLeave={() => {
-                    this.onUnHover();
-                  }}
-                >
-                  ?
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
         <table className="assay-table" style={{overflowWrap: 'break-word'}}>
         <colgroup>
           <col width="15%"/>
@@ -326,9 +281,42 @@ class AssayPanel extends React.Component {
           <col width="17%"/>
           <col width="17%"/>
         </colgroup>
-          <thead>
+          <thead style={{ verticalAlign: "text-top" }}>
             <tr class="header-cells">
-              <th>{" "}</th>
+              <th>
+                <div className="help-toggle">
+                  {this.props.toggle_help && (
+                    <div className="toggle-activebutton">
+                      <button 
+                        onClick={() => this.toggleHelp()}
+                        onMouseEnter={() => {
+                          this.onHover("help");
+                        }}
+                        onMouseLeave={() => {
+                          this.onUnHover();
+                        }}
+                      >
+                        ?
+                      </button>
+                    </div>
+                  )}
+                  {this.props.toggle_help == false && (
+                    <div className="toggle-inactivebutton">
+                      <button 
+                        onClick={() => this.toggleHelp()}
+                        onMouseEnter={() => {
+                          this.onHover("help");
+                        }}
+                        onMouseLeave={() => {
+                          this.onUnHover();
+                        }}
+                      >
+                        ?
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </th>
               <th
                 onMouseEnter={() => {
                   this.onHover("pic50");
@@ -406,8 +394,8 @@ class AssayPanel extends React.Component {
               <td>{" "}</td>
               <td>{" "}</td>
             </tr>
-            {data.map((val) => (
-              <tr key={val}>
+            {data.map((val, index) => (
+              <tr key={val} className={index % 2 === 0 ? 'even' : 'odd'}>
                 <td>{val}</td>
                 <td>
                   <input type="checkbox"  
@@ -530,7 +518,15 @@ class AssayPanel extends React.Component {
                 this.onUnHover();
               }}
             >
-              <div className="assay-name">Run Assays</div>
+              <div className="assay-name"><b>Run Assays</b></div>
+                <div className="invoice-amount">
+                  <div style={duration_color}>
+                    Duration: {this.runAssaysLimit().time} weeks
+                  </div>
+                  <div style={cost_color}>
+                    Cost: £{this.runAssaysLimit().money}
+                  </div>
+                </div>
             </button>
             {this.state.hover == "run" && this.props.toggle_help && (
               <div className="hover-info-text-run">
@@ -539,23 +535,6 @@ class AssayPanel extends React.Component {
                 </p>
               </div>
             )}
-          </div>
-          <div className="nav-buttons">
-            <Link to="/build">
-              <button 
-                label="Back_Build" 
-              >
-                Back (Design)
-              </button>
-            </Link>
-            <Link to="/analysis">
-              <button 
-                label="Next_Analysis" 
-                onClick={this.initPlotData}
-              >
-                Next (Analysis)
-              </button>
-            </Link>
           </div>
         </div>
       </div>

--- a/src/components/assay/assay_panel.js
+++ b/src/components/assay/assay_panel.js
@@ -283,7 +283,7 @@ class AssayPanel extends React.Component {
         </colgroup>
           <thead style={{ verticalAlign: "text-top" }}>
             <tr class="header-cells">
-              <th>
+              <th style={{ backgroundColor: 'white' }}>
                 <div className="help-toggle">
                   {this.props.toggle_help && (
                     <div className="toggle-activebutton">
@@ -335,7 +335,7 @@ class AssayPanel extends React.Component {
                   this.onUnHover();
                 }}
               >
-                Mouse Clearance
+                Mouse <br /> Clearance
               </th>
               <th
                 onMouseEnter={() => {
@@ -345,7 +345,7 @@ class AssayPanel extends React.Component {
                   this.onUnHover();
                 }}
               >
-                Human Clearance
+                {" "}Human <br />Clearance
               </th>
               <th
                 onMouseEnter={() => {

--- a/src/components/assay/control_panel.js
+++ b/src/components/assay/control_panel.js
@@ -19,10 +19,10 @@ class ControlPanel extends React.Component {
     return ( 
       <div className="control-panel">
         <Link to="/build">
-          <button> {'<< Design << '} </button>
+          <button> {'← Design'} </button>
         </Link>
         <Link to="/analysis">
-          <button onClick={this.initPlotData}>Next (Analysis)</button>
+          <button onClick={this.initPlotData}>Analysis →</button>
         </Link>
       </div>
     );

--- a/src/components/assay/molecule_widget.js
+++ b/src/components/assay/molecule_widget.js
@@ -2,7 +2,6 @@ import React from "react";
 import "./assay.css";
 import MoleculeImage from "./molecule_image.js";
 import MoleculeStats from "./molecule_stats_widget.js";
-import { connect } from "react-redux"
 
 class MoleculeWidget extends React.Component {
   constructor(props) {
@@ -10,12 +9,9 @@ class MoleculeWidget extends React.Component {
   }
 
   render() {
-    const selected_mol_style = {
-      borderWidth:  (this.props.selected_mol == this.props.mol_id ? "8px" : "1px")
-    };
     return (
       <div className="molecule-container">
-        <div className="molecule-widget" style={selected_mol_style}>
+        <div className="molecule-widget">
           <MoleculeImage mol_id={this.props.mol_id} />
           {this.props.mol_id}
           <MoleculeStats mol_id={this.props.mol_id} />
@@ -25,10 +21,4 @@ class MoleculeWidget extends React.Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    selected_mol: state.selector.selected_mol
-  };
-}
-
-export default connect(mapStateToProps)(MoleculeWidget);
+export default MoleculeWidget;

--- a/src/components/builder/builder.css
+++ b/src/components/builder/builder.css
@@ -166,10 +166,12 @@
   align-items: end;
   padding-bottom: 10pt;
   justify-content: flex-start;
+  text-align: left;
+  max-width: 175px;
 }
 
-.build > .molecule-chooser-bar p{
-  margin-right: 60px;
+.build > .molecule-chooser-bar > p {
+  margin-right: 49px;
 }
 
 .build > .molecule-chooser-bar > .molecule-list {
@@ -183,6 +185,7 @@
 
 .build > .molecule-chooser-bar > .molecule-list > .molecule-container {
   padding-top: 5px;
+  max-width: 170px;
 }
 
 .build > .molecule-chooser-bar > .molecule-list > .molecule-container > .molecule-card{

--- a/src/components/builder/control_panel.js
+++ b/src/components/builder/control_panel.js
@@ -51,7 +51,7 @@ class ControlPanel extends React.Component {
           <button onClick={this.resetRGroups}>Clear</button>
           { (this.props.selected_r_groups.A == 'A00' || this.props.selected_r_groups.B == 'B00')? '' : <button onClick={this.saveMolecule}>Make</button>}
           <Link to="/assay">
-            <button onClick={this.initSelectMolecule}>Test</button>
+            <button onClick={this.initSelectMolecule}>Test →</button>
           </Link>
         </div>)
     }

--- a/src/components/introduction/introduction.js
+++ b/src/components/introduction/introduction.js
@@ -61,14 +61,14 @@ class Introduction extends React.Component {
                   <div>
                   <button className='next-button' onClick={this.onNext}>Next</button>
                   <Link to="/loadingpage">
-                  <button>Skip</button>
+                  <button>Skip →</button>
                 </Link>
                 </div>
                 }
           
                 {this.state.count === 3 &&
                   <Link to="/loadingpage">
-                            <button className='start-button'>Start game</button>
+                            <button className='start-button'>Start game →</button>
                 </Link>}
 
               </div>

--- a/src/components/results/results.js
+++ b/src/components/results/results.js
@@ -67,7 +67,7 @@ class Results extends React.Component {
               </div>
               <div className="control-panel">
                 <Link to="/analysis">
-                  <button> {'<<Analysis<<'} </button>
+                  <button> {'← Analysis'} </button>
                 </Link>
                 <Link to="/">
                   <button onClick={this.save_and_resetGame}> End Game </button>


### PR DESCRIPTION
- Replaces ordering with grid system
- Removes molecule visualiser box and ordering buttons for individual molecules
- Constantly shows invoice
- Shows molecule descriptors and Lipinski rules without having to run them 
- Once an assay is run, relevant box will be disabled, allowing user to see order history
- Fixes limits on time/cost (this time it actually works) 
- Changed entire styling of page
- Changed where info text from toggle button is triggered