### PR TITLE
Slight addition to #343 to keep consistent sizing

### DIFF
--- a/src/components/analysis/molecule_widget.js
+++ b/src/components/analysis/molecule_widget.js
@@ -17,7 +17,8 @@ class MoleculeWidget extends React.Component {
 
   render() {
     const selected_mol_style = {
-      borderWidth:  (this.props.selected_mol == this.props.mol_id ? "8px" : "1px")
+      borderWidth:  (this.props.selected_mol == this.props.mol_id ? "8px" : "1px"),
+      padding: (this.props.selected_mol == this.props.mol_id ? "5px" : "13px")
     };
     return (
       <div className="molecule-container">

--- a/src/components/builder/r_group_widget.js
+++ b/src/components/builder/r_group_widget.js
@@ -28,7 +28,8 @@ class RGroupWidget extends React.Component {
 
   render() {
     const selected_r_group_style = {
-      borderWidth:  (this.props.selected_r_groups["A"] == this.props.r_group_id || this.props.selected_r_groups["B"] == this.props.r_group_id ? "8px" : "1px")
+      borderWidth:  (this.props.selected_r_groups["A"] == this.props.r_group_id || this.props.selected_r_groups["B"] == this.props.r_group_id ? "8px" : "1px"),
+      padding: (this.props.selected_r_groups["A"] == this.props.r_group_id || this.props.selected_r_groups["B"] == this.props.r_group_id ? "5px" : "13px")
     };
     return (
       <div className="r-group-container">


### PR DESCRIPTION
Adds padding to r-group/molecule widgets in lists to keep consistent size when the border widths change