### PR TITLE
#402 added openssl build legacy workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "ketcher-standalone": "^1.3.1"
   },
   "scripts": {
-    "start": "react-scripts --max_old_space_size=4096 start",
-    "build": "react-scripts --max_old_space_size=4096 build",
+    "start": "react-scripts --openssl-legacy-provider --max_old_space_size=4096 start",
+    "build": "react-scripts --openssl-legacy-provider --max_old_space_size=4096 build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
fixed issue with OpenSSL dependency - check that npm start and npm install still run