### PR TITLE
#451 Fix navigation bar links

### DIFF
--- a/src/components/body/navigation.js
+++ b/src/components/body/navigation.js
@@ -1,9 +1,20 @@
 import React from "react";
+import { connect } from "react-redux";
+import { selectorActions } from "../../actions";
 import { NavLink } from "react-router-dom";
 
 import "./navigation.css";
 
 class Navigation extends React.Component {
+  // set the first saved molecule as the selected molecule for assay and docking pages
+  initSelectMolecule = () => {
+    const keys = Object.keys(this.props.saved_mols);
+    if (keys.length > 0) {
+      // Assuming you want to select the first molecule if there are any
+      this.props.selectMolecule(keys[0]);
+    }
+  };
+
   render() {
     return(
         <div className="navigation">
@@ -32,22 +43,22 @@ class Navigation extends React.Component {
                   
                 </li>
                 <li className="navigation-item">
-                  <NavLink className="navigation-link" to="/docking">
+                  <NavLink className="navigation-link" to="/docking" onClick={this.initSelectMolecule}>
                     Docking
                   </NavLink>
                 </li>
                 <li className="navigation-item">
-                  <NavLink className="navigation-link" to="/assay">
+                  <NavLink className="navigation-link" to="/assay" onClick={this.initSelectMolecule}>
                     Test
                   </NavLink>
                 </li>
                 <li className="navigation-item">
-                  <NavLink className="navigation-link" to="/analysis">
+                  <NavLink className="navigation-link" to="/analysis" onClick={this.initSelectMolecule}>
                     Analysis
                   </NavLink>
                 </li>
                 <li className="navigation-item">
-                  <NavLink className="navigation-link" to="/results">
+                  <NavLink className="navigation-link" to="/results" onClick={this.initSelectMolecule}>
                     Results
                   </NavLink>
                 </li>
@@ -58,4 +69,14 @@ class Navigation extends React.Component {
   )};
 }
 
-export default Navigation
+function mapStateToProps(state) {
+  return {
+    saved_mols: state.assay.saved_mols,
+  };
+}
+
+const actionCreators = {
+  selectMolecule: selectorActions.selectMolecule,
+};
+
+export default connect(mapStateToProps, actionCreators)(Navigation);


### PR DESCRIPTION
If a new molecule is made, initSelectMol needs to be called when navigating to any of the subsequent pages after the builder from the navigation bar. The initSelectMol function was modified to handle the case where no new molecule is saved. 