### PR TITLE
#450-aligned-buttons-docking

### DIFF
--- a/src/components/docking/docking.css
+++ b/src/components/docking/docking.css
@@ -11,7 +11,7 @@
   display: flex;               /* Use flexbox for layout */
   flex-direction: column;      /* Lay out child elements in a column */
   height: 100%;                /* Take up the full height of its parent */
-  min-width: 70%;              /* Minimum width set to 70% of parent */
+  min-width: 71%;              /* Minimum width set to 71% of parent - This value aligns buttons with edges of docking window */
   padding-left: 3vw;           /* Padding from left as 3% of viewport width */
   padding-right: 3vw;          /* Padding from right as 3% of viewport width */
   padding-top: 3vh;            /* Padding from top as 3% of viewport height */

--- a/src/components/docking/docking.js
+++ b/src/components/docking/docking.js
@@ -80,20 +80,20 @@ class Docking extends React.Component {
             <div className="affinity">
               Affinity score:{" "} 
               {this.props.saved_mols[this.props.selected_mol].data.drug_props.docking_affinity} kcal/mol
-              <div className="nav-buttons">
-                <Link to="/build">
-                  <button>
-                    ← Design 
-                  </button>
-                </Link>
-                <Link to="/assay">
-                  <button
-                    onClick={this.initPlotData}   // When clicking on Analysis, it initializes the plot data
+            </div>
+            <div className="nav-buttons">
+              <Link to="/build">
+                <button>
+                  ← Design 
+                </button>
+              </Link>
+              <Link to="/assay">
+                <button
+                  onClick={this.initPlotData}   // When clicking on Analysis, it initializes the plot data
                   >
-                    Test →
-                  </button>
-                </Link>
-              </div>
+                  Test →
+                </button>
+              </Link>
             </div>
           </div>
         </div> ) : (


### PR DESCRIPTION
Previously buttons in docking page were aligned in a visually displeasing manner (one of them aligned with edge of docking window, the other didn't); fixed this.