### PR TITLE
backend PORT changed to 8000 in the scipts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ package-lock.json
 /build
 
 # misc
-.DS_Store
+/.DS_Store
 .env.local
 .env.development.local
 .env.test.local

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_BASE_URL = "http://127.0.0.1:5000";
+const API_BASE_URL = "http://127.0.0.1:8000";
 // const API_BASE_URL = 'https://drug-discovery-game-backend.onrender.com';
 // const API_BASE_URL = 'https://drug-design-game-backend.onrender.com';
 

--- a/src/components/docking/docking.js
+++ b/src/components/docking/docking.js
@@ -36,7 +36,7 @@ class Docking extends React.Component {
   // Render method defines the UI of the component
   render() {
     // Define a URL which is used to fetch molecule data
-    let url = `http://localhost:5000/docking-${this.props.selected_mol}dock1_concatenated.pdb`;
+    let url = `http://localhost:8000/docking-${this.props.selected_mol}dock1_concatenated.pdb`;
 
     // Define properties for the Molstar component
     let molstar_props = {


### PR DESCRIPTION
- must be run with:
- "flask run -p 8000" on the backend terminal - can run on backend main.
- This over-rides flask default port 5000 as on newer macs this is taken up by AirTunes. 
- Docking should work and CORS issue resolves.
